### PR TITLE
Update litter-robot.groovy

### DIFF
--- a/devicetypes/natekspencer/litter-robot.src/litter-robot.groovy
+++ b/devicetypes/natekspencer/litter-robot.src/litter-robot.groovy
@@ -68,7 +68,9 @@ metadata {
 		attribute "litterRobotId", "string"
 		attribute "lastCleaned", "string"	
 		attribute "drawerLevel", "number"
-		
+	// lastStatusCode values for LR full: DF1 = 1st trip of DFI sensor, DF2 = First cycle after DFI tripped, DFS = Litter Robot will no longer cycle     
+		attribute "lastStatusCode", "string"
+	    
         command "lightOn"
         command "lightOff"
         command "panelLockOn"
@@ -78,6 +80,7 @@ metadata {
         command "sleepOn"
         command "sleepOff"
         command "resetDrawerGauge"
+	command "startCleanCycle"
     }
     
     preferences {

--- a/devicetypes/natekspencer/litter-robot.src/litter-robot.groovy
+++ b/devicetypes/natekspencer/litter-robot.src/litter-robot.groovy
@@ -80,7 +80,7 @@ metadata {
         command "sleepOn"
         command "sleepOff"
         command "resetDrawerGauge"
-	command "startCleanCycle"
+		command "startCleanCycle"
     }
     
     preferences {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,12 +1,12 @@
 {
   "packageName": "Litter Robot Integration",
   "author": "Nathan Spencer & Dominick Meglio",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "minimumHEVersion": "2.1.9",
-  "releaseNotes": "Fixed a bug preventing the force clean cycle from working properly",
+  "releaseNotes": "Added lastStatusCode as an attribute and startCleanCycle as a command",
   "licenseFile": "https://raw.githubusercontent.com/dcmeglio/hubitat-litterrobot/master/LICENSE",
   "documentationLink": "https://github.com/dcmeglio/hubitat-litterrobot/blob/master/README.md",
-  "dateReleased": "2020-04-10",
+  "dateReleased": "2021-02-10",
   "apps": [
     {
       "id": "de135b2f-fe3f-4b98-98d5-43be99cb6c71",


### PR DESCRIPTION
Line 71/72: Expose "lastStatusCode" attribute.  This is a deterministic way to know that the Litter Robot is full.  Value of DF1 = DFI sensor has been tripped,  DF2 = First Cycle after DFI has been tripped, and DFS = Litter Robot will no longer cycle.  Added appropriate comment.
Line 83: Expose "startCleanCycle" as a button and as an action.  While "On" does the same thing, it's best to expose the explicit command as the LR app also contains this.